### PR TITLE
Revenue dash support

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -61,42 +61,31 @@ test('runEveryMinute', async () => {
 
     await runEveryMinute(getMeta())
 
-    const testNumberOfCaptureCalls = () => {
-        expect(posthog.capture).toHaveBeenCalledTimes(5)
-    }
-    testNumberOfCaptureCalls()
+    expect(posthog.capture).toHaveBeenCalledTimes(5)
 
-    const testUpcomingInvoice = () => {
-        expect(posthog.capture).toHaveBeenCalledWith('Upcoming Invoice', {
-            distinct_id: 'cus_J632IbQFZfXXt5',
-            amount: 150,
-            invoice_date: '02/03/2021',
-            stripe_customer_id: 'cus_J632IbQFZfXXt5',
-            quantity: 0,
-            $set: undefined
-        })
-    }
-    testUpcomingInvoice()
+    expect(posthog.capture).toHaveBeenCalledWith('Upcoming Invoice', {
+        distinct_id: 'cus_J632IbQFZfXXt5',
+        amount: 150,
+        invoice_date: '02/03/2021',
+        stripe_customer_id: 'cus_J632IbQFZfXXt5',
+        quantity: 0,
+        $set: undefined
+    })
 
-    const testPaidInvoices = () => {
-        const today = new Date()
-        const firstDayThisMonth = new Date(today.getFullYear(), today.getMonth(), 1)
-        const invoicePeriod = firstDayThisMonth.toLocaleDateString('en-GB')
-        expect(posthog.capture).toHaveBeenCalledWith('Paid Invoices', { amount: 0, period: invoicePeriod })
-    }
-    testPaidInvoices()
+    expect(posthog.capture).toHaveBeenCalledWith('Upcoming Invoice – Above Threshold', {
+        distinct_id: 'cus_J632IbQFZfXXt5',
+        amount: 150,
+        invoice_date: '02/03/2021',
+        stripe_customer_id: 'cus_J632IbQFZfXXt5',
+        alert_threshold: 100,
+        product: undefined,
+        quantity: 0,
+        $set: undefined
+    })
 
-    const testInvoiceAlerts = () => {
-        expect(posthog.capture).toHaveBeenCalledWith('Upcoming Invoice – Above Threshold', {
-            distinct_id: 'cus_J632IbQFZfXXt5',
-            amount: 150,
-            invoice_date: '02/03/2021',
-            stripe_customer_id: 'cus_J632IbQFZfXXt5',
-            alert_threshold: 100,
-            product: undefined,
-            quantity: 0,
-            $set: undefined
-        })
-    }
-    testInvoiceAlerts()
+    // Paid invoices should be scoped to the current month
+    const today = new Date()
+    const firstDayThisMonth = new Date(today.getFullYear(), today.getMonth(), 1)
+    const invoicePeriod = firstDayThisMonth.toLocaleDateString('en-GB')
+    expect(posthog.capture).toHaveBeenCalledWith('Paid Invoices', { amount: 0, period: invoicePeriod })
 })

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -64,6 +64,7 @@ test('runEveryMinute', async () => {
     const testNumberOfCaptureCalls = () => {
         expect(posthog.capture).toHaveBeenCalledTimes(5)
     }
+    testNumberOfCaptureCalls()
 
     const testUpcomingInvoice = () => {
         expect(posthog.capture).toHaveBeenCalledWith('Upcoming Invoice', {
@@ -75,6 +76,7 @@ test('runEveryMinute', async () => {
             $set: undefined
         })
     }
+    testUpcomingInvoice()
 
     const testPaidInvoices = () => {
         const today = new Date()
@@ -82,6 +84,7 @@ test('runEveryMinute', async () => {
         const invoicePeriod = firstDayThisMonth.toLocaleDateString('en-GB')
         expect(posthog.capture).toHaveBeenCalledWith('Paid Invoices', { amount: 0, period: invoicePeriod })
     }
+    testPaidInvoices()
 
     const testInvoiceAlerts = () => {
         expect(posthog.capture).toHaveBeenCalledWith('Upcoming Invoice – Above Threshold', {
@@ -95,9 +98,5 @@ test('runEveryMinute', async () => {
             $set: undefined
         })
     }
-
-    testNumberOfCaptureCalls()
-    testUpcomingInvoice()
-    testPaidInvoices()
     testInvoiceAlerts()
 })

--- a/index.js
+++ b/index.js
@@ -65,7 +65,6 @@ async function fetchAllCustomers(defaultHeaders) {
 
 async function runEveryMinute({ global, storage, cache }) {
     const ONE_HOUR = 1000 * 60 * 60 * 1
-
     // Run every one hour - Using runEveryMinute to run on setup
     // const lastRun = await cache.get('_lastRun')
     // if (lastRun && new Date().getTime() - Number(lastRun) < ONE_HOUR) {

--- a/index.js
+++ b/index.js
@@ -81,11 +81,11 @@ async function capturePaidInvoices(defaultHeaders, customerIgnoreRegex) {
     const statusParam = '&status=paid'
 
     while (invoiceJson.has_more) {
-        const paymentResponse = await fetchWithRetry(
+        const invoiceResponse = await fetchWithRetry(
             `https://api.stripe.com/v1/invoices?limit=100&${dateParam}${statusParam}${paginationParam}`,
             defaultHeaders
         )
-        invoiceJson = await paymentResponse.json()
+        invoiceJson = await invoiceResponse.json()
         const newPayments = invoiceJson.data
 
         if (!newPayments) {

--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ async function runEveryMinute({ global, storage, cache }) {
         if (global.onlyRegisterNewCustomers && customerRecordExists) {
             continue
         } else {
-            posthog.capture(customerRecordExists ? 'Updated Stripe Customer' : 'p Identified Stripe Customer', {
+            posthog.capture(customerRecordExists ? 'Updated Stripe Customer' : 'Identified Stripe Customer', {
                 distinct_id: customer.email || customer.id,
                 $set: {
                     ...basicProperties,

--- a/index.js
+++ b/index.js
@@ -65,11 +65,12 @@ async function fetchAllCustomers(defaultHeaders) {
 
 async function runEveryMinute({ global, storage, cache }) {
     const ONE_HOUR = 1000 * 60 * 60 * 1
+
     // Run every one hour - Using runEveryMinute to run on setup
-    const lastRun = await cache.get('_lastRun')
-    if (lastRun && new Date().getTime() - Number(lastRun) < ONE_HOUR) {
-        return
-    }
+    // const lastRun = await cache.get('_lastRun')
+    // if (lastRun && new Date().getTime() - Number(lastRun) < ONE_HOUR) {
+    //     return
+    // }
 
     const customers = await fetchAllCustomers(global.defaultHeaders)
 

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ async function fetchAllCustomers(defaultHeaders) {
 }
 
 async function capturePaidInvoices(defaultHeaders, customerIgnoreRegex) {
-    let payments = []
+    let invoices = []
 
     let paginationParam = ''
     let invoiceJson = { has_more: true }
@@ -94,11 +94,11 @@ async function capturePaidInvoices(defaultHeaders, customerIgnoreRegex) {
 
         const lastObjectId = newPayments[newPayments.length - 1].id
         paginationParam = `&starting_after=${lastObjectId}`
-        payments = [...payments, ...newPayments]
+        invoices = [...invoices, ...newPayments]
     }
 
     const cleanedPayments = []
-    payments.forEach((payment) => {
+    invoices.forEach((payment) => {
         if (!customerIgnoreRegex || !customerIgnoreRegex.test(payment.customer_email)) {
             cleanedPayments.push({
                 email: payment.customer_email,
@@ -115,7 +115,7 @@ async function capturePaidInvoices(defaultHeaders, customerIgnoreRegex) {
     cleanedPayments.forEach((payment) => {
         paymentsReceived += payment.amount_paid
     })
-    posthog.debug = true
+
     posthog.capture('Paid Invoices', {
         period: firstDayThisMonth.toLocaleDateString('en-GB'),
         amount: parseFloat((paymentsReceived / 100).toFixed(2))

--- a/index.js
+++ b/index.js
@@ -71,11 +71,11 @@ async function runEveryMinute({ global, storage, cache }) {
         return
     }
 
-    let customers = await fetchAllCustomers(global.defaultHeaders)
+    const customers = await fetchAllCustomers(global.defaultHeaders)
 
     const invoicesByProduct = {}
 
-    for (let customer of customers) {
+    for (const customer of customers) {
         // Ignore customers matching the user-specified regex
         if (customer.email && global.customerIgnoreRegex && global.customerIgnoreRegex.test(customer.email)) {
             continue
@@ -161,16 +161,16 @@ async function runEveryMinute({ global, storage, cache }) {
         }
 
         if (global.onlyRegisterNewCustomers && customerRecordExists) {
-            break
+            continue
+        } else {
+            posthog.capture(customerRecordExists ? 'Updated Stripe Customer' : 'p Identified Stripe Customer', {
+                distinct_id: customer.email || customer.id,
+                $set: {
+                    ...basicProperties,
+                    ...{ subscribed_product: productName }
+                }
+            })
         }
-
-        posthog.capture(customerRecordExists ? 'Updated Stripe Customer' : 'Identified Stripe Customer', {
-            distinct_id: customer.email || customer.id,
-            $set: {
-                ...basicProperties,
-                ...{ subscribed_product: productName }
-            }
-        })
     }
 
     logAggregatedInvoices(invoicesByProduct)

--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ async function capturePaidInvoices(defaultHeaders, customerIgnoreRegex) {
     cleanedPayments.forEach((payment) => {
         paymentsReceived += payment.amount_paid
     })
-
+    posthog.debug = true
     posthog.capture('Paid Invoices', {
         period: firstDayThisMonth.toLocaleDateString('en-GB'),
         amount: parseFloat((paymentsReceived / 100).toFixed(2))
@@ -125,10 +125,10 @@ async function capturePaidInvoices(defaultHeaders, customerIgnoreRegex) {
 async function runEveryMinute({ global, storage, cache }) {
     const ONE_HOUR = 1000 * 60 * 60 * 1
     // Run every one hour - Using runEveryMinute to run on setup
-    // const lastRun = await cache.get('_lastRun')
-    // if (lastRun && new Date().getTime() - Number(lastRun) < ONE_HOUR) {
-    //     return
-    // }
+    const lastRun = await cache.get('_lastRun')
+    if (lastRun && new Date().getTime() - Number(lastRun) < ONE_HOUR) {
+        return
+    }
 
     const customers = await fetchAllCustomers(global.defaultHeaders)
 

--- a/index.js
+++ b/index.js
@@ -97,23 +97,11 @@ async function capturePaidInvoices(defaultHeaders, customerIgnoreRegex) {
         invoices = [...invoices, ...newPayments]
     }
 
-    const cleanedPayments = []
+    let paymentsReceived = 0.0
     invoices.forEach((payment) => {
         if (!customerIgnoreRegex || !customerIgnoreRegex.test(payment.customer_email)) {
-            cleanedPayments.push({
-                email: payment.customer_email,
-                amount_due: payment.amount_due,
-                amount_paid: payment.amount_paid,
-                status: payment.status,
-                created: new Date(payment.created * 1000).toLocaleDateString('en-GB'),
-                currency: payment.currency
-            })
+            paymentsReceived += payment.amount_paid
         }
-    })
-
-    let paymentsReceived = 0.0
-    cleanedPayments.forEach((payment) => {
-        paymentsReceived += payment.amount_paid
     })
 
     posthog.capture('Paid Invoices', {

--- a/plugin.json
+++ b/plugin.json
@@ -54,6 +54,14 @@
             "type": "string",
             "default": "100",
             "required": false
+        },
+        {
+            "key": "capturePaidInvoices",
+            "hint": "If enabled, will tally all paid invoices created in the current month and capture as an event.",
+            "name": "Capture paid invoices:",
+            "type": "string",
+            "default": "Yes",
+            "required": false
         }
     ]
 }


### PR DESCRIPTION
Adding one more event:

If `capturePaidInvoices` is enabled:
- Retrieve all **paid** invoices created within the current month
- Sum these invoices and capture as an event

This will let us tracking payments received in the month, and hopefully lets @piemets move away from pulling invoices manually.