### PR TITLE
chore: pin to node 18

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
             # Install Node.js
             - uses: actions/setup-node@v1
               with:
-                  node-version: 14
+                  node-version: 18
 
             # Install dependencies
             - run: yarn

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
     "version": "1.0.3",
     "description": "Get customer and invoice data from Stripe into PostHog.",
     "main": "index.ts",
+    "engines": {
+        "node": ">=18.0.0 <19.0.0"
+    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/PostHog/stripe-plugin.git"


### PR DESCRIPTION
The tests do not run on node 19, and at any rate, the plugin-server is
running on node 18.