### PR TITLE
ci: use yarn cache to speed up CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,7 @@ jobs:
             - uses: actions/setup-node@v1
               with:
                   node-version: 18
+                  cache: "yarn"
 
             # Install dependencies
             - run: yarn


### PR DESCRIPTION
It actually seems pretty fast already, but this should help a bit.