### PR TITLE
fix: Check if customer is null when getting id

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -135,7 +135,7 @@ test('runEveryMinute', async () => {
 
     expect(fetch).toHaveBeenCalledTimes(2)
     expect(posthog.api.get).toHaveBeenCalledTimes(2)
-    expect(posthog.capture).toHaveBeenCalledTimes(6)
+    expect(posthog.capture).toHaveBeenCalledTimes(5)
 
     expect(posthog.capture).toHaveBeenNthCalledWith(1, 'Stripe Customer Created', {
         distinct_id: 'test_distinct_id',
@@ -175,7 +175,7 @@ test('runEveryMinute', async () => {
     // second pagination, we should be the stripe page, but nothing else should happen
     await runEveryMinute(meta)
     expect(posthog.api.get).toHaveBeenCalledTimes(2)
-    expect(posthog.capture).toHaveBeenCalledTimes(6)
+    expect(posthog.capture).toHaveBeenCalledTimes(5)
     expect(fetch).toHaveBeenCalledTimes(3)
 
     // Pretend we've gone all the way round

--- a/index.ts
+++ b/index.ts
@@ -127,7 +127,8 @@ async function sendSubscriptionEvent(subscription, customer, storage, groupAddit
         }
     })
 
-    const id = customer?.id || subscription.id;
+    const id = customer?.id || subscription.id
+
     await storage.set(`subscription_${id}`, true)
 }
 

--- a/index.ts
+++ b/index.ts
@@ -127,7 +127,8 @@ async function sendSubscriptionEvent(subscription, customer, storage, groupAddit
         }
     })
 
-    await storage.set(`subscription_${customer.id}`, true)
+    const id = customer?.id || subscription.id;
+    await storage.set(`subscription_${id}`, true)
 }
 
 async function getGroupTypeKey(person_id, global) {


### PR DESCRIPTION
`customer` can be `null` according to commit https://github.com/PostHog/stripe-plugin/commit/868df74995609be6bb04f207250ad9aac271ba25. We are checking for this in line 118:
```
        distinct_id: customer?.distinct_id,
```

However, if `customer` is indeed `null` then line 130 will also fail:

```
    await storage.set(`subscription_${customer.id}`, true)
```

This PR adds another `null` check in this line.

Maybe https://github.com/PostHog/stripe-plugin/issues/19