### PR TITLE
feat: Support using invoice `paid_at` state transition timestamp for "Invoice Paid" event

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
             # Install Node.js
             - uses: actions/setup-node@v1
               with:
-                  node-version: 18
+                  node-version: 18.12.1
                   cache: "yarn"
 
             # Install dependencies

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,5 +1,5 @@
 import { getMeta, resetMeta } from '@posthog/plugin-scaffold/test/utils.js'
-import { setupPlugin, jobs, runEveryMinute } from './index'
+import { setupPlugin, jobs, runEveryMinute, INVOICE_EVENT_TIMESTAMP_TYPES } from './index'
 import 'jest'
 
 global.fetch = jest.fn(async (url) => ({
@@ -43,6 +43,7 @@ beforeEach(() => {
     posthog.api.get.mockClear()
     global.groupType = undefined
     global.groupTypeIndex = undefined
+    global.getInvoiceTimestamp = INVOICE_EVENT_TIMESTAMP_TYPES['Invoice Period End Date']
 
     mockStorage = new Map()
     storage = {

--- a/index.test.ts
+++ b/index.test.ts
@@ -121,7 +121,11 @@ test('setupPlugin groupType and groupTypeIndex need to be set', async () => {
     await setupPlugin({ ...meta, config: { groupTypeIndex: 0, groupType: 'test' } })
 })
 
-test('runEveryMinute', async () => {
+test.each([
+    ['Invoice Period End Date', '2022-07-27T16:00:09.000Z'],
+    ['Invoice Payment Date','2022-07-27T17:28:20.000Z'],
+])('runEveryMinute', async (invoiceEventTimestampType, invoiceTimestamp) => {
+    global.getInvoiceTimestamp = INVOICE_EVENT_TIMESTAMP_TYPES[invoiceEventTimestampType]
     expect(fetch).toHaveBeenCalledTimes(0)
     expect(posthog.capture).toHaveBeenCalledTimes(0)
 
@@ -158,7 +162,7 @@ test('runEveryMinute', async () => {
 
     expect(posthog.capture).toHaveBeenNthCalledWith(3, 'Stripe Invoice Paid', {
         distinct_id: 'test_distinct_id',
-        timestamp: '2022-07-27T16:00:09.000Z',
+        timestamp: invoiceTimestamp,
         stripe_customer_id: 'cus_stripeid1',
         stripe_amount_paid: 2000,
         stripe_amount_due: 2000,

--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,7 @@ interface StoredInvoice {
 }
 
 // Keep this in sync with the `invoiceEventTimestamp` choices in config.json!
-const INVOICE_EVENT_TIMESTAMP_TYPES: Record<string, (invoice: StoredInvoice) => Date | undefined> = {
+export const INVOICE_EVENT_TIMESTAMP_TYPES: Record<string, (invoice: StoredInvoice) => Date | undefined> = {
     'Invoice Period End Date': (invoice) => new Date(invoice.period_end * 1000),
     'Invoice Payment Date': (invoice) => {
         // older invoices may have been written without state transition data
@@ -99,8 +99,8 @@ async function sendGroupEvent(invoice, customer, due_last_month, due_total, paid
 
 function last_month(global, invoices: StoredInvoice[], key) {
     const today = new Date()
-    const firstDayThisMonth = Math.floor(new Date(today.getFullYear(), today.getMonth(), 1) / 1000)
-    const firstDayNextMonth = Math.floor(new Date(today.getFullYear(), today.getMonth() + 1, 1) / 1000)
+    const firstDayThisMonth = new Date(today.getFullYear(), today.getMonth(), 1)
+    const firstDayNextMonth = new Date(today.getFullYear(), today.getMonth() + 1, 1)
     return invoices
         .filter((invoice) => {
             const timestamp = global.getInvoiceTimestamp(invoice)

--- a/plugin.json
+++ b/plugin.json
@@ -34,6 +34,13 @@
             "choices": ["Yes", "No"],
             "default": "No",
             "hint": "If there is a user in Stripe that we can't find in PostHog, should we still send events?"
+        },
+        {
+            "key": "invoiceTimestampType",
+            "name": "Timestamp to use for Invoice Paid events",
+            "type": "choice",
+            "choices": ["Invoice Period End Date", "Invoice Payment Date"],
+            "default": "Invoice Period End Date"
         }
     ]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -36,7 +36,7 @@
             "hint": "If there is a user in Stripe that we can't find in PostHog, should we still send events?"
         },
         {
-            "key": "invoiceTimestampType",
+            "key": "invoiceEventTimestamp",
             "name": "Timestamp to use for Invoice Paid events",
             "type": "choice",
             "choices": ["Invoice Period End Date", "Invoice Payment Date"],


### PR DESCRIPTION
The plugin currently uses `invoice.period_at` to generate the timestamp for the "Stripe Invoice Paid" event, which doesn't make sense for all use cases. This allows using the timestamp of the state transition instead if preferred by the user, defaulting to the current behavior to maintain reverse compatibility for anyone who may depend on it working as-is.